### PR TITLE
Add client-configurable TTLs with a maximum of 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,17 @@ cat <<EOF >> ~/.ssh/aegis_config
 AUTH_DOMAIN="https://login.example.com"
 CLIENT_ID="ABCD"
 AEGIS_ENDPOINT="https://abcx.execute-api.us-east-1.amazonaws.com/..."
+DEFAUlt_TTL="24h"
 EOF
 ```
 
 Alternatively, you can pass the values directly via the command line:
 ```bash
 ./aegis \
-  --auth-url https://login.example.com \
-  --clientid ABCD \
-  --aegis-endpoint https://abcx.execute-api.us-east-1.amazonaws.com/...
+  -auth-url https://login.example.com \
+  -clientid ABCD \
+  -aegis-endpoint https://abcx.execute-api.us-east-1.amazonaws.com/...
+  -ttl 1h
 ```
 
 

--- a/cmd/aegis/config.go
+++ b/cmd/aegis/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -14,6 +15,7 @@ type ClientConfig struct {
 	AegisEndpoint string
 	Scope         string
 	KeyOutputPath string
+	DefaultTTL    time.Duration
 }
 
 func createAegisConfigDir() error {
@@ -34,12 +36,21 @@ func loadConfig() ClientConfig {
 		godotenv.Load(configFile)
 	}
 
+	// calc default ttl
+	defaultTTL, err := time.ParseDuration(getEnv("DEFAULT_TTL", "24h"))
+	if err != nil {
+		fmt.Printf("Error parsing DEFAULT_TTL: %v\n", err)
+		fmt.Println("Falling back to default value of 24 hours.")
+		defaultTTL = 24 * time.Hour // Fallback to 24 hours
+	}
+
 	return ClientConfig{
 		AuthDomain:    getEnv("AUTH_DOMAIN", ""),
 		ClientID:      getEnv("CLIENT_ID", ""),
 		AegisEndpoint: getEnv("AEGIS_ENDPOINT", ""),
 		Scope:         getEnv("SCOPE", "openid email profile sign:user_key"),
 		KeyOutputPath: getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
+		DefaultTTL:    defaultTTL,
 	}
 }
 

--- a/cmd/aegis/config.go
+++ b/cmd/aegis/config.go
@@ -15,7 +15,7 @@ type ClientConfig struct {
 	AegisEndpoint string
 	Scope         string
 	KeyOutputPath string
-	DefaultTTL    time.Duration
+	TTL           time.Duration
 }
 
 func createAegisConfigDir() error {
@@ -50,7 +50,7 @@ func loadConfig() ClientConfig {
 		AegisEndpoint: getEnv("AEGIS_ENDPOINT", ""),
 		Scope:         getEnv("SCOPE", "openid email profile sign:user_key"),
 		KeyOutputPath: getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
-		DefaultTTL:    defaultTTL,
+		TTL:           defaultTTL,
 	}
 }
 

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -116,12 +116,12 @@ func saveKeyPair(pubKey, signedPubKey, privKey string) {
 	}
 }
 
-func submitPublicKeyForAegisSigning(accessToken string, pubKey string) ([]byte, error) {
+func submitPublicKeyForAegisSigning(accessToken string, request signer.PublicKeySignRequest) ([]byte, error) {
 	// Create a new Aegis client
 	aegisClient := signer.NewAegisClient(config.AegisEndpoint, accessToken)
 
 	// Submit the public key to Aegis for signing
-	signedPubKey, err := aegisClient.SubmitPublicKey(pubKey)
+	signedPubKey, err := aegisClient.SubmitPublicKey(request)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,10 @@ func main() {
 	// Submit the public key to Aegis for signing
 	fmt.Println("🚀 Submitting public key to Aegis for signing...")
 
-	signedPubKey, err := submitPublicKeyForAegisSigning(oauthToken.AccessToken, pubKey)
+	signedPubKey, err := submitPublicKeyForAegisSigning(oauthToken.AccessToken, signer.PublicKeySignRequest{
+		PublicKey: pubKey,
+		TTL:       24 * time.Hour,
+	})
 	if err != nil {
 		fatal("Failed to submit public key for signing: %v", err)
 	}

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -62,7 +62,7 @@ func init() {
 		if err != nil {
 			fatal("Error parsing -ttl: %v", err)
 		}
-		config.DefaultTTL = parsedTTL
+		config.TTL = parsedTTL
 	}
 
 	// Check for required configuration values
@@ -171,7 +171,7 @@ func main() {
 
 	signedPubKey, err := submitPublicKeyForAegisSigning(oauthToken.AccessToken, signer.PublicKeySignRequest{
 		PublicKey: pubKey,
-		TTL:       24 * time.Hour,
+		TTL:       config.TTL,
 	})
 	if err != nil {
 		fatal("Failed to submit public key for signing: %v", err)

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -19,6 +19,7 @@ var (
 	aegisEndpointFlag string
 	configPathFlag    string
 	keyOutputPathFlag string
+	ttlFlag           string
 	config            ClientConfig
 )
 
@@ -37,6 +38,7 @@ func init() {
 	flag.BoolVar(&verboseFlag, "verbose", false, "Enable verbose output")
 	flag.StringVar(&configPathFlag, "config", filepath.Join(os.Getenv("HOME"), ".config/aegis"), "Path to the configuration file")
 	flag.StringVar(&keyOutputPathFlag, "key-output-path", filepath.Join(os.Getenv("HOME"), ".ssh"), "Path to save the generated keys")
+	flag.StringVar(&ttlFlag, "ttl", "24h", "Time to live for the signed key")
 	flag.Parse()
 
 	// Load environment variables
@@ -54,6 +56,13 @@ func init() {
 	}
 	if keyOutputPathFlag != "" {
 		config.KeyOutputPath = keyOutputPathFlag
+	}
+	if ttlFlag != "" {
+		parsedTTL, err := time.ParseDuration(ttlFlag)
+		if err != nil {
+			fatal("Error parsing -ttl: %v", err)
+		}
+		config.DefaultTTL = parsedTTL
 	}
 
 	// Check for required configuration values

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -40,12 +40,31 @@ func ParseJWTClaims(tokenString string) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("invalid token claims type")
 }
 
+func ParseTTL(ttl string) (time.Duration, error) {
+	parsedTTL, err := time.ParseDuration(ttl)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse ttl: %w", err)
+	}
+
+	if parsedTTL <= 0 {
+		return 0, fmt.Errorf("ttl must be greater than 0")
+	}
+
+	// set max TTL to 30 days
+	// This is a measure to prevent long-lived certificates
+	if parsedTTL > time.Duration(30*24*time.Hour) {
+		return 0, fmt.Errorf("ttl is too long")
+	}
+
+	return parsedTTL, nil
+}
+
 // NewHandler creates a new Lambda handler function
 func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	return func(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 
 		slog.Info("Starting Aegis Signer Lambda function")
-		const certificateExpiration = 24 * time.Hour
+		var certificateExpiration = time.Duration(24 * time.Hour)
 
 		// Parse the JWT token to get the Claims
 		authHeader := event.Headers["authorization"] // Header keys may be lowercased by API Gateway
@@ -86,6 +105,17 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 		if err != nil {
 			slog.Error("failed to parse submitted public key", "error", err)
 			return events.APIGatewayV2HTTPResponse{StatusCode: 400, Body: "invalid public key"}, nil
+		}
+
+		// Use the ttl from the query string if provided
+		// otherwise use the default TTL
+		if rawTTL := event.QueryStringParameters["ttl"]; rawTTL != "" {
+			ttl, err := ParseTTL(rawTTL)
+			if err != nil {
+				slog.Error("failed to parse ttl", "error", err)
+				return events.APIGatewayV2HTTPResponse{StatusCode: 400, Body: err.Error()}, nil
+			}
+			certificateExpiration = ttl
 		}
 
 		// Sign the certificate using the Signer

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,16 +42,20 @@ func ParseJWTClaims(tokenString string) (map[string]interface{}, error) {
 }
 
 func ParseTTL(ttl string) (time.Duration, error) {
-	parsedTTL, err := time.ParseDuration(ttl)
+	// Parse the TTL string as an integer in minutes
+	ttlMinutes, err := strconv.Atoi(ttl)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse ttl: %w", err)
 	}
+
+	// Convert the minutes to time.Duration
+	parsedTTL := time.Duration(ttlMinutes) * time.Minute
 
 	if parsedTTL <= 0 {
 		return 0, fmt.Errorf("ttl must be greater than 0")
 	}
 
-	// set max TTL to 30 days
+	// Set max TTL to 30 days
 	// This is a measure to prevent long-lived certificates
 	if parsedTTL > time.Duration(30*24*time.Hour) {
 		return 0, fmt.Errorf("ttl is too long")
@@ -100,8 +105,6 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 			return events.APIGatewayV2HTTPResponse{StatusCode: 200, Body: "no principals matched on auth token"}, nil
 		}
 
-		slog.Info("mapped principals from token claims", "principals", principals)
-
 		// Parse the public key from the request body
 		pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(event.Body))
 		if err != nil {
@@ -110,7 +113,6 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 		}
 
 		// Use the ttl from the query string if provided
-		// otherwise use the default TTL
 		if rawTTL := event.QueryStringParameters["ttl"]; rawTTL != "" {
 			ttl, err := ParseTTL(rawTTL)
 			if err != nil {

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -80,6 +80,7 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 		tokenStr := strings.TrimPrefix(authHeader, prefix)
 
 		parsedTokenClaims, err := ParseJWTClaims(tokenStr)
+		slog.Info("Parsed JWT claims", "claims", parsedTokenClaims)
 		if err != nil {
 			return events.APIGatewayV2HTTPResponse{StatusCode: 500, Body: "Failed to parse jwt token"}, nil
 		}
@@ -93,6 +94,7 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 
 		// Map the JWT claims to SSH principals
 		principals, err := deps.PrincipalMapper.Map(parsedTokenClaims)
+		slog.Info("Mapped principals from JWT claims", "principals", principals)
 		if err != nil {
 			slog.Info("No principals matched from token, no cert generated", "error", err)
 			return events.APIGatewayV2HTTPResponse{StatusCode: 200, Body: "no principals matched on auth token"}, nil
@@ -115,6 +117,7 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 				slog.Error("failed to parse ttl", "error", err)
 				return events.APIGatewayV2HTTPResponse{StatusCode: 400, Body: err.Error()}, nil
 			}
+			slog.Info("Parsed TTL from query string", "ttl", ttl)
 			certificateExpiration = ttl
 		}
 
@@ -124,6 +127,7 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 			slog.Error("failed to sign certificate", "error", err)
 			return events.APIGatewayV2HTTPResponse{StatusCode: 500, Body: "failed to sign certificate"}, nil
 		}
+		slog.Info("Successfully signed certificate", "certificate", userSSHCert.KeyId)
 
 		slog.Info("ssh key signed", "principals", principals, "ttl", certificateExpiration.String())
 

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -129,9 +129,6 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 		}
 		slog.Info("Successfully signed certificate", "certificate", userSSHCert.KeyId)
 
-		slog.Info("ssh key signed", "principals", principals, "ttl", certificateExpiration.String())
-		slog.Info("Successfully signed certificate", "certificate", userSSHCert.KeyId)
-
 		// Return the SSH certificate in response
 		certString := string(ssh.MarshalAuthorizedKey(userSSHCert))
 
@@ -152,7 +149,6 @@ func NewHandler(deps LambdaDeps) func(ctx context.Context, event events.APIGatew
 
 		if err := deps.AuditRepo.Write(keySignEvent); err != nil {
 			slog.Error("Failed to write audit log", "error", err)
-			slog.Info("Audit Event", "data", keySignEvent)
 		}
 
 		return events.APIGatewayV2HTTPResponse{

--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -177,7 +177,7 @@ func TestLambdaHandlerWithTTls(t *testing.T) {
 		},
 		{
 			name:               "Custom TTL",
-			ttl:                "12h",
+			ttl:                "720",
 			expectedTTL:        12 * time.Hour,
 			expectedStatusCode: 200,
 		},
@@ -189,19 +189,19 @@ func TestLambdaHandlerWithTTls(t *testing.T) {
 		},
 		{
 			name:               "Negative TTL",
-			ttl:                "-1h",
+			ttl:                "-60",
 			expectedTTL:        0,
 			expectedStatusCode: 400,
 		},
 		{
 			name:               "Zero TTL",
-			ttl:                "0s",
+			ttl:                "0",
 			expectedTTL:        0,
 			expectedStatusCode: 400,
 		},
 		{
 			name:               "TTL > 30 days",
-			ttl:                "31d",
+			ttl:                "44640",
 			expectedTTL:        0,
 			expectedStatusCode: 400,
 		},

--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/golang-jwt/jwt/v5"
@@ -159,4 +160,87 @@ func TestLambdaHandlerWithNoMatchingClaims(t *testing.T) {
 
 	assert.Equal(t, "no principals matched on auth token", resp.Body)
 
+}
+
+func TestLambdaHandlerWithTTls(t *testing.T) {
+	tests := []struct {
+		name               string
+		ttl                string
+		expectedTTL        time.Duration
+		expectedStatusCode int
+	}{
+		{
+			name:               "Default TTL",
+			ttl:                "",
+			expectedTTL:        24 * time.Hour,
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "Custom TTL",
+			ttl:                "12h",
+			expectedTTL:        12 * time.Hour,
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "Invalid TTL",
+			ttl:                "invalid",
+			expectedTTL:        0,
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "Negative TTL",
+			ttl:                "-1h",
+			expectedTTL:        0,
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "Zero TTL",
+			ttl:                "0s",
+			expectedTTL:        0,
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "TTL > 30 days",
+			ttl:                "31d",
+			expectedTTL:        0,
+			expectedStatusCode: 400,
+		},
+	}
+
+	pubkey, _, err := signer.NewSSHKeyPair(signer.ECDSA)
+	assert.NoError(t, err)
+
+	handler := setupHandler("name")
+	tokenString, err := signJWTWithSecret(map[string]string{"name": "ruse"}, "test123")
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			event := events.APIGatewayV2HTTPRequest{
+				Headers: map[string]string{
+					"authorization": "Bearer " + tokenString,
+				},
+				RawPath: "/sign_user_key",
+				Body:    pubkey,
+				QueryStringParameters: map[string]string{
+					"ttl": tt.ttl,
+				},
+			}
+
+			resp, err := handler(context.Background(), event)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+
+			if tt.expectedStatusCode == 200 {
+				parsedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(resp.Body))
+				assert.NoError(t, err)
+
+				sshCert, ok := parsedKey.(*ssh.Certificate)
+				assert.True(t, ok)
+				assert.LessOrEqual(t, sshCert.ValidBefore, uint64(time.Now().Add(tt.expectedTTL).Unix()))
+			}
+		})
+	}
 }

--- a/internal/signer/client.go
+++ b/internal/signer/client.go
@@ -54,7 +54,10 @@ func (c *AegisClient) SubmitPublicKey(data PublicKeySignRequest) ([]byte, error)
 	req.Header.Set("Content-Type", "text/plain")
 
 	if data.TTL > 0 {
-		req.URL.Query().Set("ttl", fmt.Sprintf("%d", int(data.TTL.Minutes())))
+		ttlMinutes := int(data.TTL.Minutes())
+		query := req.URL.Query()
+		query.Set("ttl", fmt.Sprintf("%d", ttlMinutes))
+		req.URL.RawQuery = query.Encode()
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/signer/client.go
+++ b/internal/signer/client.go
@@ -5,13 +5,22 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // PublicKeySigner defines the methods for interacting with a key signing service.
 type PublicKeySigner interface {
 	// SubmitPublicKey submits a public key to the server.
 	// It returns the signed public key or an error if the request fails.
-	SubmitPublicKey(accessToken, pubKey string) ([]byte, error)
+	SubmitPublicKey(PublicKeySignRequest) ([]byte, error)
+}
+
+type PublicKeySignRequest struct {
+	// PublicKey is the public key to be signed.
+	PublicKey string
+
+	// TTL is the time-to-live for the signed key in minutes. (optional)
+	TTL time.Duration
 }
 
 type AegisClient struct {
@@ -33,8 +42,9 @@ func NewAegisClient(endpoint, accessToken string) *AegisClient {
 }
 
 // SubmitPublicKey submits a public key to the signing service and returns the signed public key.
-func (c *AegisClient) SubmitPublicKey(pubKey string) ([]byte, error) {
-	req, err := http.NewRequest("POST", c.Endpoint, bytes.NewBufferString(pubKey))
+// It takes an access token, the public key, and an optional TTL (time-to-live) for the signed key in minutes.
+func (c *AegisClient) SubmitPublicKey(data PublicKeySignRequest) ([]byte, error) {
+	req, err := http.NewRequest("POST", c.Endpoint, bytes.NewBufferString(data.PublicKey))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
@@ -42,6 +52,10 @@ func (c *AegisClient) SubmitPublicKey(pubKey string) ([]byte, error) {
 
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Content-Type", "text/plain")
+
+	if data.TTL > 0 {
+		req.URL.Query().Set("ttl", fmt.Sprintf("%d", int(data.TTL.Minutes())))
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/signer/client_test.go
+++ b/internal/signer/client_test.go
@@ -5,20 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sebastian-mora/aegis/internal/signer"
 )
 
-func TestSubmitPublicKey(t *testing.T) {
-	client := signer.NewAegisClient("http://localhost:8080", "test-token")
-
-	// Create mock api
+func TestSubmitPublicKey_Valid(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -27,32 +24,45 @@ func TestSubmitPublicKey(t *testing.T) {
 			http.Error(w, "Unsupported Media Type", http.StatusUnsupportedMediaType)
 			return
 		}
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
-			return
-		}
-
+		body, _ := io.ReadAll(r.Body)
 		if string(body) != "pubkey" {
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
 		}
-		defer r.Body.Close()
-
-		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("signed-key"))
 	}))
 	defer server.Close()
-	client.Endpoint = server.URL
 
-	signedKey, err := client.SubmitPublicKey("pubkey")
+	client := signer.NewAegisClient(server.URL, "test-token")
+	req := signer.PublicKeySignRequest{
+		PublicKey: "pubkey",
+		TTL:       24 * time.Hour,
+	}
+
+	resp, err := client.SubmitPublicKey(req)
 	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(signedKey) != "signed-key" {
-		t.Fatalf("expected signed key to be 'signed-key', got %s", signedKey)
+	if string(resp) != "signed-key" {
+		t.Errorf("expected 'signed-key', got %q", resp)
+	}
+}
+
+func TestSubmitPublicKey_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := signer.NewAegisClient(server.URL, "") // No token
+	req := signer.PublicKeySignRequest{
+		PublicKey: "pubkey",
+		TTL:       24 * time.Hour,
 	}
 
+	_, err := client.SubmitPublicKey(req)
+	if err == nil {
+		t.Fatal("expected error for unauthorized request, got nil")
+	}
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.96.0"
   hashes = [
     "h1:a/VEUu6BGQSPlUAzbN+zqaDCdi0QGh/VzBgo2gCran0=",
+    "h1:hqoQJnKaTfzNge5oCELAs+jqiT0R0oygDYlG4pmy3yk=",
     "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
     "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
     "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",


### PR DESCRIPTION

This PR enables clients to configure TTLs (time-to-live) when requesting certificates. TTLs are specified via the CLI using human-readable duration strings like "1m" or "1h". These are parsed into minutes and sent to the API as a ttl URL query parameter.

Key changes:

- TTLs are now accepted from the client and passed as a `ttl` query parameter.
- TTLs must be greater than zero and no more than 30 days (to prevent long-lived certs).
- TTLs are parsed from strings like "5m" or "2h" and converted to minutes before being sent.