### PR TITLE
Refactoring the CLI main.go and added Testing

### DIFF
--- a/cmd/aegis/config.go
+++ b/cmd/aegis/config.go
@@ -28,12 +28,11 @@ func createAegisConfigDir() error {
 	return nil
 }
 
-func loadConfig() ClientConfig {
+func loadConfig(file string) ClientConfig {
 
 	// if the config file exists in the config directory, load it
-	configFile := filepath.Join(os.Getenv("HOME"), ".config/aegis", "config")
-	if _, err := os.Stat(configFile); err == nil {
-		godotenv.Load(configFile)
+	if _, err := os.Stat(file); err == nil {
+		godotenv.Load(file)
 	}
 
 	// calc default ttl

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -91,7 +91,7 @@ func authenticateUser(cfg ClientConfig) (*oauth2.Token, error) {
 	return token, nil
 }
 
-func saveKeyPair(cfg ClientConfig, pubKey, signedPubKey, privKey string) {
+func saveKeyPair(cfg ClientConfig, pubKey, signedPubKey, privKey string) error {
 	files := map[string]string{
 		"aegis.pub":      pubKey,
 		"aegis":          privKey,
@@ -101,9 +101,11 @@ func saveKeyPair(cfg ClientConfig, pubKey, signedPubKey, privKey string) {
 	for name, content := range files {
 		path := filepath.Join(cfg.KeyOutputPath, name)
 		if err := WriteKeyToFile(path, content); err != nil {
-			fatalf("failed to write %s: %v", name, err)
+			return fmt.Errorf("failed to write %s: %v", name, err)
 		}
 	}
+
+	return nil
 }
 
 func submitPublicKeyForSigning(cfg ClientConfig, token string, pubKey string) ([]byte, error) {
@@ -145,7 +147,10 @@ func run(cfg ClientConfig) error {
 		return fmt.Errorf("signing failed: %w", err)
 	}
 
-	saveKeyPair(cfg, pubKey, string(signedPubKey), privKey)
+	err = saveKeyPair(cfg, pubKey, string(signedPubKey), privKey)
+	if err != nil {
+		return fmt.Errorf("failed to save key pair: %w", err)
+	}
 
 	fmt.Printf("\tPublic key saved to: %s/aegis.pub\n", cfg.KeyOutputPath)
 	fmt.Printf("\tPrivate key saved to: %s/aegis\n", cfg.KeyOutputPath)

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -20,19 +20,10 @@ var (
 	configPathFlag    string
 	keyOutputPathFlag string
 	ttlFlag           string
-	config            ClientConfig
 )
 
-func init() {
-
-	//
-	err := createAegisConfigDir()
-	if err != nil {
-		fatal("Failed to create config directory: %v", err)
-	}
-
-	// Parse flags
-	flag.StringVar(&authDomainFlag, "auth-url", "", "Url to the authentication server")
+func initFlags() {
+	flag.StringVar(&authDomainFlag, "auth-url", "", "URL to the authentication server")
 	flag.StringVar(&clientIDFlag, "client-id", "", "Client ID for the authentication server")
 	flag.StringVar(&aegisEndpointFlag, "aegis-endpoint", "", "Aegis endpoint")
 	flag.BoolVar(&verboseFlag, "verbose", false, "Enable verbose output")
@@ -40,147 +31,146 @@ func init() {
 	flag.StringVar(&keyOutputPathFlag, "key-output-path", filepath.Join(os.Getenv("HOME"), ".ssh"), "Path to save the generated keys")
 	flag.StringVar(&ttlFlag, "ttl", "24h", "Time to live for the signed key")
 	flag.Parse()
+}
 
-	// Load environment variables
-	config = loadConfig()
+func loadClientConfig() (ClientConfig, error) {
+	cfg := loadConfig()
 
-	// Override with command-line flags if provided
+	// Override with CLI flags if provided
 	if authDomainFlag != "" {
-		config.AuthDomain = authDomainFlag
+		cfg.AuthDomain = authDomainFlag
 	}
 	if clientIDFlag != "" {
-		config.ClientID = clientIDFlag
+		cfg.ClientID = clientIDFlag
 	}
 	if aegisEndpointFlag != "" {
-		config.AegisEndpoint = aegisEndpointFlag
+		cfg.AegisEndpoint = aegisEndpointFlag
 	}
 	if keyOutputPathFlag != "" {
-		config.KeyOutputPath = keyOutputPathFlag
+		cfg.KeyOutputPath = keyOutputPathFlag
 	}
 	if ttlFlag != "" {
 		parsedTTL, err := time.ParseDuration(ttlFlag)
 		if err != nil {
-			fatal("Error parsing -ttl: %v", err)
+			return cfg, fmt.Errorf("invalid TTL: %w", err)
 		}
-		config.TTL = parsedTTL
+		cfg.TTL = parsedTTL
 	}
 
-	// Check for required configuration values
-	if config.AuthDomain == "" || config.ClientID == "" || config.AegisEndpoint == "" {
-		fatal("Missing required configuration values. Please provide them via flags or in the environment.")
+	if cfg.AuthDomain == "" || cfg.ClientID == "" || cfg.AegisEndpoint == "" {
+		return cfg, fmt.Errorf("missing required config values (auth-url, client-id, aegis-endpoint)")
 	}
 
-	// Optional: Print verbose output
-	if verboseFlag {
-		fmt.Printf("Using configuration: %+v\n", config)
-	}
+	return cfg, nil
 }
 
-func WriteKeyToFile(name, key string) error {
-	err := os.WriteFile(filepath.Join(config.KeyOutputPath, name), []byte(key), 0600)
-	if err != nil {
-		return fmt.Errorf("write key to file failed: %w", err)
-	}
-	return nil
-}
-
-func fatal(format string, args ...any) {
+func fatalf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "❌ "+format+"\n", args...)
 	os.Exit(1)
 }
 
-func authenticateUser() *oauth2.Token {
+func WriteKeyToFile(path, key string) error {
+	return os.WriteFile(path, []byte(key), 0600)
+}
 
-	// Create a new OAuth2 config
-	oauthConfig := &oauth2.Config{
-		ClientID: config.ClientID,
+func authenticateUser(cfg ClientConfig) (*oauth2.Token, error) {
+	oauthCfg := &oauth2.Config{
+		ClientID: cfg.ClientID,
 		Endpoint: oauth2.Endpoint{
-			DeviceAuthURL: config.AuthDomain + "/application/o/device/",
-			TokenURL:      config.AuthDomain + "/application/o/token/",
+			DeviceAuthURL: cfg.AuthDomain + "/application/o/device/",
+			TokenURL:      cfg.AuthDomain + "/application/o/token/",
 		},
-		Scopes: []string{config.Scope},
+		Scopes: []string{cfg.Scope},
 	}
 
-	// Request a token
 	ctx := context.Background()
-	token, err := RequestDeviceCode(ctx, oauthConfig)
+	token, err := RequestDeviceCode(ctx, oauthCfg)
 	if err != nil {
-		fatal("Failed to request device code: %v", err)
+		return nil, fmt.Errorf("failed to request device code: %v", err)
 	}
-
-	return token
+	return token, nil
 }
 
-func saveKeyPair(pubKey, signedPubKey, privKey string) {
+func saveKeyPair(cfg ClientConfig, pubKey, signedPubKey, privKey string) {
+	files := map[string]string{
+		"aegis.pub":      pubKey,
+		"aegis":          privKey,
+		"aegis-cert.pub": signedPubKey,
+	}
 
-	// Save the keys to files
-	if err := WriteKeyToFile("aegis.pub", pubKey); err != nil {
-		fatal("Failed to write public key to file: %v", err)
-	}
-	if err := WriteKeyToFile("aegis", privKey); err != nil {
-		fatal("Failed to write private key to file: %v", err)
-	}
-	if err := WriteKeyToFile("aegis-cert.pub", string(signedPubKey)); err != nil {
-		fatal("Failed to write certificate to file: %v", err)
+	for name, content := range files {
+		path := filepath.Join(cfg.KeyOutputPath, name)
+		if err := WriteKeyToFile(path, content); err != nil {
+			fatalf("failed to write %s: %v", name, err)
+		}
 	}
 }
 
-func submitPublicKeyForAegisSigning(accessToken string, request signer.PublicKeySignRequest) ([]byte, error) {
-	// Create a new Aegis client
-	aegisClient := signer.NewAegisClient(config.AegisEndpoint, accessToken)
-
-	// Submit the public key to Aegis for signing
-	signedPubKey, err := aegisClient.SubmitPublicKey(request)
-	if err != nil {
-		return nil, err
-	}
-
-	return signedPubKey, nil
+func submitPublicKeyForSigning(cfg ClientConfig, token string, pubKey string) ([]byte, error) {
+	client := signer.NewAegisClient(cfg.AegisEndpoint, token)
+	return client.SubmitPublicKey(signer.PublicKeySignRequest{
+		PublicKey: pubKey,
+		TTL:       cfg.TTL,
+	})
 }
 
-func main() {
+func run(cfg ClientConfig) error {
 	fmt.Println("🔐 Aegis Signer CLI")
 
-	// Get or authenticate the user to get an access token
-	oauthToken, err := LoadToken(configPathFlag + "/token.json")
-	if err != nil {
-		fatal("Failed to load access token: %v", err)
-	}
+	token, err := LoadToken(filepath.Join(configPathFlag, "token.json"))
+	if err != nil || token == nil || token.Expiry.Before(time.Now()) {
+		token, err = authenticateUser(cfg)
+		if err != nil {
+			return fmt.Errorf("authentication failed: %w", err)
+		}
 
-	// If we failed to load a cached token or it's expired, reauth
-	if oauthToken == nil || oauthToken.Expiry.Before(time.Now()) {
-		oauthToken = authenticateUser()
-		if err := SaveToken(configPathFlag+"/token.json", oauthToken); err != nil {
-			fatal("Failed to save access token: %v", err)
+		// Save the token for future use
+		if err := SaveToken(filepath.Join(configPathFlag, "token.json"), token); err != nil {
+			return fmt.Errorf("failed to save token: %w", err)
 		}
 	}
 
-	tokenClaims, _ := ParseAccessToken(oauthToken.AccessToken)
-	fmt.Printf("👤 User authenticated: %s\n", tokenClaims.Name)
+	claims, _ := ParseAccessToken(token.AccessToken)
+	fmt.Printf("👤 User authenticated: %s\n", claims.Name)
 
-	// Generate a new Ed25519 key pair
 	fmt.Println("🔑 Generating Ed25519 key pair...")
-
 	pubKey, privKey, err := signer.NewSSHKeyPair(signer.Ed25519)
 	if err != nil {
-		fatal("Failed to generate key pair: %v", err)
+		return fmt.Errorf("failed to generate key pair: %w", err)
 	}
 
-	// Submit the public key to Aegis for signing
 	fmt.Println("🚀 Submitting public key to Aegis for signing...")
-
-	signedPubKey, err := submitPublicKeyForAegisSigning(oauthToken.AccessToken, signer.PublicKeySignRequest{
-		PublicKey: pubKey,
-		TTL:       config.TTL,
-	})
+	signedPubKey, err := submitPublicKeyForSigning(cfg, token.AccessToken, pubKey)
 	if err != nil {
-		fatal("Failed to submit public key for signing: %v", err)
+		return fmt.Errorf("signing failed: %w", err)
 	}
 
-	// Save the keys to files
-	saveKeyPair(pubKey, string(signedPubKey), privKey)
-	fmt.Printf("\tPublic key saved to: %s/aegis.pub\n", config.KeyOutputPath)
-	fmt.Printf("\tPrivate key saved to: %s/aegis\n", config.KeyOutputPath)
-	fmt.Printf("\tCertificate saved to: %s/aegis-cert.pub\n", config.KeyOutputPath)
+	saveKeyPair(cfg, pubKey, string(signedPubKey), privKey)
 
+	fmt.Printf("\tPublic key saved to: %s/aegis.pub\n", cfg.KeyOutputPath)
+	fmt.Printf("\tPrivate key saved to: %s/aegis\n", cfg.KeyOutputPath)
+	fmt.Printf("\tCertificate saved to: %s/aegis-cert.pub\n", cfg.KeyOutputPath)
+
+	return nil
+}
+
+func main() {
+	initFlags()
+
+	if err := createAegisConfigDir(); err != nil {
+		fatalf("failed to create config directory: %v", err)
+	}
+
+	cfg, err := loadClientConfig()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if verboseFlag {
+		fmt.Printf("Using configuration: %+v\n", cfg)
+	}
+
+	if err := run(cfg); err != nil {
+		fatalf(err.Error())
+	}
 }

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -27,7 +27,7 @@ func initFlags() {
 	flag.StringVar(&clientIDFlag, "client-id", "", "Client ID for the authentication server")
 	flag.StringVar(&aegisEndpointFlag, "aegis-endpoint", "", "Aegis endpoint")
 	flag.BoolVar(&verboseFlag, "verbose", false, "Enable verbose output")
-	flag.StringVar(&configPathFlag, "config", filepath.Join(os.Getenv("HOME"), ".config/aegis"), "Path to the configuration file")
+	flag.StringVar(&configPathFlag, "config", filepath.Join(os.Getenv("HOME"), ".config/aegis/config"), "Path to the configuration file")
 	flag.StringVar(&keyOutputPathFlag, "key-output-path", filepath.Join(os.Getenv("HOME"), ".ssh"), "Path to save the generated keys")
 	flag.StringVar(&ttlFlag, "ttl", "24h", "Time to live for the signed key")
 	flag.Parse()
@@ -119,7 +119,9 @@ func submitPublicKeyForSigning(cfg ClientConfig, token string, pubKey string) ([
 func run(cfg ClientConfig) error {
 	fmt.Println("🔐 Aegis Signer CLI")
 
-	token, err := LoadToken(filepath.Join(configPathFlag, "token.json"))
+	tokenPath := filepath.Join(filepath.Dir(configPathFlag), "token.json")
+	token, err := LoadToken(tokenPath)
+
 	if err != nil || token == nil || token.Expiry.Before(time.Now()) {
 		token, err = authenticateUser(cfg)
 		if err != nil {
@@ -127,7 +129,7 @@ func run(cfg ClientConfig) error {
 		}
 
 		// Save the token for future use
-		if err := SaveToken(filepath.Join(configPathFlag, "token.json"), token); err != nil {
+		if err := SaveToken(tokenPath, token); err != nil {
 			return fmt.Errorf("failed to save token: %w", err)
 		}
 	}

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -34,7 +34,7 @@ func initFlags() {
 }
 
 func loadClientConfig() (ClientConfig, error) {
-	cfg := loadConfig()
+	cfg := loadConfig(configPathFlag)
 
 	// Override with CLI flags if provided
 	if authDomainFlag != "" {

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -133,6 +134,34 @@ func TestRun_SignError(t *testing.T) {
 		ClientID:      "mock-client-id",
 		AegisEndpoint: signerServer.URL,
 		KeyOutputPath: t.TempDir(),
+		TTL:           1 * time.Hour,
+	}
+
+	err := run(cfg)
+	assert.Error(t, err)
+}
+
+func TestRun_WriteKeyToFileError(t *testing.T) {
+	// Create a temporary directory and remove it to simulate a write error
+	tempDir := t.TempDir()
+	if err := os.Remove(tempDir); err != nil {
+		t.Fatalf("failed to remove temp dir: %v", err)
+	}
+
+	// signer server returns 500 Internal Server Error
+	signerServer := mockSignerServer()
+	defer signerServer.Close()
+
+	deviceCodeServer := mockDeviceCodeServer()
+	defer deviceCodeServer.Close()
+
+	configPathFlag = t.TempDir()
+
+	cfg := ClientConfig{
+		AuthDomain:    deviceCodeServer.URL,
+		ClientID:      "mock-client-id",
+		AegisEndpoint: signerServer.URL,
+		KeyOutputPath: tempDir, // use the removed path here
 		TTL:           1 * time.Hour,
 	}
 

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -168,3 +168,35 @@ func TestRun_WriteKeyToFileError(t *testing.T) {
 	err := run(cfg)
 	assert.Error(t, err)
 }
+
+func TestLoadClientConfigf(t *testing.T) {
+	// Create a temporary config file
+	tempFile, err := os.CreateTemp("", "config.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	// Write mock config data to the file
+	configData := `
+	DEFAULT_TTL=1h
+	AUTH_DOMAIN=https://mock.auth.domain
+	CLIENT_ID=mock-client-id
+	AEGIS_ENDPOINT=https://mock.aegis.endpoint
+	KEY_OUTPUT_PATH=/mock/key/output/path
+	`
+	if _, err := tempFile.WriteString(configData); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+
+	// write the config path to the temp file
+	configPathFlag = tempFile.Name()
+
+	cfg, err := loadClientConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://mock.auth.domain", cfg.AuthDomain)
+	assert.Equal(t, "mock-client-id", cfg.ClientID)
+	assert.Equal(t, "https://mock.aegis.endpoint", cfg.AegisEndpoint)
+	assert.Equal(t, "/mock/key/output/path", cfg.KeyOutputPath)
+	assert.Equal(t, time.Hour, cfg.TTL)
+}

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -89,3 +89,26 @@ func TestRun_Success(t *testing.T) {
 	err := run(cfg)
 	assert.NoError(t, err)
 }
+
+func TestRun_InvalidDeviceCode(t *testing.T) {
+	// device code server returns 400 Bad Request
+	deviceCodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer deviceCodeServer.Close()
+
+	signerServer := mockSignerServer()
+	defer signerServer.Close()
+
+	cfg := ClientConfig{
+		AuthDomain:    deviceCodeServer.URL,
+		ClientID:      "mock-client-id",
+		AegisEndpoint: signerServer.URL,
+		KeyOutputPath: t.TempDir(),
+		TTL:           1 * time.Hour,
+	}
+
+	err := run(cfg)
+	assert.Error(t, err)
+
+}

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -54,7 +54,7 @@ func mockDeviceCodeServer() *httptest.Server {
 	mux.HandleFunc("/application/o/device/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"device_code": "mock-device-code", "user_code": "mock-user-code", "verification_uri": "https://mock.verification.uri"}`))
+		w.Write([]byte(`{"device_code": "mock-device-code", "user_code": "mock-user-code", "verification_uri": "https://mock.verification.uri", "interval": 1 }`))
 	})
 
 	mux.HandleFunc("/application/o/token/", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+)
+
+type Signer interface {
+	Sign(certType uint32, publickkey ssh.PublicKey, principals []string, expiration time.Duration) (*ssh.Certificate, error)
+}
+
+type mockSigner struct {
+}
+
+func (m *mockSigner) Sign(certType uint32, publickkey ssh.PublicKey, principals []string, expiration time.Duration) (*ssh.Certificate, error) {
+	return &ssh.Certificate{}, nil
+}
+
+func GenerateMockJWT(claims map[string]interface{}, secret string) (string, error) {
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	// Convert map to jwt.MapClaims
+	mapClaims := jwt.MapClaims{}
+	for k, v := range claims {
+		mapClaims[k] = v
+	}
+	token.Claims = mapClaims
+
+	// Sign the token with the secret
+	return token.SignedString([]byte(secret))
+}
+
+// Create test http mock server that signs the public key
+func mockSignerServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"signed_key": "mocked-signed-key"}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func mockDeviceCodeServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/application/o/device/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"device_code": "mock-device-code", "user_code": "mock-user-code", "verification_uri": "https://mock.verification.uri"}`))
+	})
+
+	mux.HandleFunc("/application/o/token/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// create token with claims
+		claims := map[string]interface{}{
+			"sub":  "mock-subject",
+			"name": "mock-name",
+			"exp":  time.Now().Add(1 * time.Hour).Unix(),
+		}
+		token, _ := GenerateMockJWT(claims, "test-secret")
+		w.Write([]byte(`{"access_token": "` + token + `", "expires_in": 3600}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+func TestRun_Success(t *testing.T) {
+	signerServer := mockSignerServer()
+	defer signerServer.Close()
+
+	deviceCodeServer := mockDeviceCodeServer()
+	defer deviceCodeServer.Close()
+
+	cfg := ClientConfig{
+		AuthDomain:    deviceCodeServer.URL,
+		ClientID:      "mock-client-id",
+		AegisEndpoint: signerServer.URL,
+		KeyOutputPath: t.TempDir(),
+		TTL:           1 * time.Hour,
+	}
+
+	err := run(cfg)
+	assert.NoError(t, err)
+}

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -78,6 +78,11 @@ func TestRun_Success(t *testing.T) {
 	deviceCodeServer := mockDeviceCodeServer()
 	defer deviceCodeServer.Close()
 
+	// override the config path to a temp dir
+	// this avoids writing to the user's home directory
+	// and allows for easier cleanup after tests
+	configPathFlag = t.TempDir()
+
 	cfg := ClientConfig{
 		AuthDomain:    deviceCodeServer.URL,
 		ClientID:      "mock-client-id",
@@ -110,5 +115,4 @@ func TestRun_InvalidDeviceCode(t *testing.T) {
 
 	err := run(cfg)
 	assert.Error(t, err)
-
 }

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -116,3 +116,26 @@ func TestRun_InvalidDeviceCode(t *testing.T) {
 	err := run(cfg)
 	assert.Error(t, err)
 }
+func TestRun_SignError(t *testing.T) {
+	// signer server returns 500 Internal Server Error
+	signerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer signerServer.Close()
+
+	deviceCodeServer := mockDeviceCodeServer()
+	defer deviceCodeServer.Close()
+
+	configPathFlag = t.TempDir()
+
+	cfg := ClientConfig{
+		AuthDomain:    deviceCodeServer.URL,
+		ClientID:      "mock-client-id",
+		AegisEndpoint: signerServer.URL,
+		KeyOutputPath: t.TempDir(),
+		TTL:           1 * time.Hour,
+	}
+
+	err := run(cfg)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Refactored the layout of main.go for the cli to allow for testing. Fixed a few bugs on the config path variables as well as the token caching. 