### PR TITLE
add refresh token

### DIFF
--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -48,7 +48,7 @@ func loadConfig(file string) ClientConfig {
 		AuthDomain:           getEnv("AUTH_DOMAIN", ""),
 		ClientID:             getEnv("CLIENT_ID", ""),
 		AegisEndpoint:        getEnv("AEGIS_ENDPOINT", ""),
-		Scope:                getEnv("SCOPE", "openid email profile sign:user_key"),
+		Scope:                getEnv("SCOPE", "openid email profile offline_access"),
 		KeyOutputPath:        getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
 		TTL:                  defaultTTL,
 		AuthenticationMethod: getAuthenticationMethod(),

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -48,7 +48,7 @@ func loadConfig(file string) ClientConfig {
 		AuthDomain:           getEnv("AUTH_DOMAIN", ""),
 		ClientID:             getEnv("CLIENT_ID", ""),
 		AegisEndpoint:        getEnv("AEGIS_ENDPOINT", ""),
-		Scope:                getEnv("SCOPE", "openid email profile offline_access"),
+		Scope:                getEnv("SCOPE", "openid email profile sign:user_key"),
 		KeyOutputPath:        getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
 		TTL:                  defaultTTL,
 		AuthenticationMethod: getAuthenticationMethod(),

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sebastian-mora/aegis/client"
 	"github.com/sebastian-mora/aegis/internal/signer"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -95,19 +96,32 @@ func run(cfg ClientConfig) error {
 	fmt.Println()
 
 	tokenPath := filepath.Join(filepath.Dir(configPathFlag), "token.json")
-	token, err := LoadToken(tokenPath)
+	cached, err := LoadToken(tokenPath)
 	auth := getAuthenticator(cfg)
 
-	if err != nil || token == nil || token.Expiry.Before(time.Now()) {
+	var token *oauth2.Token
+
+	// Try to refresh using cached refresh token
+	if err == nil && cached != nil && cached.RefreshToken != "" {
+		token, err = RefreshAccessToken(cfg, cached.RefreshToken)
+		if err != nil {
+			// Refresh failed (token revoked/expired), need full re-auth
+			fmt.Println("Session expired, re-authenticating...")
+			token = nil
+		}
+	}
+
+	// If no valid token, do full authentication
+	if token == nil {
 		token, err = auth.Authenticate(cfg)
 		if err != nil {
 			return fmt.Errorf("authentication failed: %w", err)
 		}
+	}
 
-		// Save the token for future use
-		if err := SaveToken(tokenPath, token); err != nil {
-			return fmt.Errorf("failed to save token: %w", err)
-		}
+	// Save refresh token (may have rotated)
+	if err := SaveToken(tokenPath, token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
 	}
 
 	claims, _ := ParseAccessToken(token.AccessToken)

--- a/cmd/cli/token.go
+++ b/cmd/cli/token.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -57,8 +58,18 @@ func ParseAccessToken(idToken string) (*IdTokenClaims, error) {
 	return &claims, nil
 }
 
+// CachedToken only stores the refresh token on disk (not access/id tokens)
+type CachedToken struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
 func SaveToken(path string, token *oauth2.Token) error {
-	data, err := json.Marshal(token)
+	// Only persist the refresh token - access tokens stay in memory only
+	cached := CachedToken{
+		RefreshToken: token.RefreshToken,
+	}
+
+	data, err := json.Marshal(cached)
 	if err != nil {
 		return err
 	}
@@ -66,7 +77,7 @@ func SaveToken(path string, token *oauth2.Token) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-func LoadToken(path string) (*oauth2.Token, error) {
+func LoadToken(path string) (*CachedToken, error) {
 	data, err := os.ReadFile(path)
 
 	if err != nil {
@@ -82,10 +93,30 @@ func LoadToken(path string) (*oauth2.Token, error) {
 		return nil, nil
 	}
 
-	var token oauth2.Token
-	if err := json.Unmarshal(data, &token); err != nil {
+	var cached CachedToken
+	if err := json.Unmarshal(data, &cached); err != nil {
 		return nil, fmt.Errorf("invalid token cache: %w", err)
 	}
 
-	return &token, nil
+	return &cached, nil
+}
+
+// RefreshAccessToken exchanges a refresh token for a fresh access token
+func RefreshAccessToken(cfg ClientConfig, refreshToken string) (*oauth2.Token, error) {
+	oauthCfg := &oauth2.Config{
+		ClientID: cfg.ClientID,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: cfg.AuthDomain + "/application/o/token/",
+		},
+		Scopes: []string{cfg.Scope},
+	}
+
+	// Create an expired token with only refresh token set
+	// oauth2 library will automatically refresh it
+	expiredToken := &oauth2.Token{
+		RefreshToken: refreshToken,
+	}
+
+	tokenSource := oauthCfg.TokenSource(context.Background(), expiredToken)
+	return tokenSource.Token()
 }


### PR DESCRIPTION
Updates the CLI to save and use refresh tokens rather than save the ID/Access tokens directly to disk

- **add refresh_token scope**
- **add method to refresh tokens**
