### PR TITLE
Terraform cleanup: fix IAM policies and remove dead code

### DIFF
--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -48,7 +48,7 @@ func loadConfig(file string) ClientConfig {
 		AuthDomain:           getEnv("AUTH_DOMAIN", ""),
 		ClientID:             getEnv("CLIENT_ID", ""),
 		AegisEndpoint:        getEnv("AEGIS_ENDPOINT", ""),
-		Scope:                getEnv("SCOPE", "openid email profile sign:user_key"),
+		Scope:                getEnv("SCOPE", "openid email profile offline_access"),
 		KeyOutputPath:        getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
 		TTL:                  defaultTTL,
 		AuthenticationMethod: getAuthenticationMethod(),

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -48,7 +48,7 @@ func loadConfig(file string) ClientConfig {
 		AuthDomain:           getEnv("AUTH_DOMAIN", ""),
 		ClientID:             getEnv("CLIENT_ID", ""),
 		AegisEndpoint:        getEnv("AEGIS_ENDPOINT", ""),
-		Scope:                getEnv("SCOPE", "openid email profile offline_access"),
+		Scope:                getEnv("SCOPE", "openid email profile sign:user_key"),
 		KeyOutputPath:        getEnv("KEY_OUTPUT_PATH", filepath.Join(os.Getenv("HOME"), ".ssh")),
 		TTL:                  defaultTTL,
 		AuthenticationMethod: getAuthenticationMethod(),

--- a/terraform/apigw.tf
+++ b/terraform/apigw.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "cloudwatch" {
       "logs:FilterLogEvents",
     ]
 
-    resources = ["*"]
+    resources = [aws_cloudwatch_log_group.apigw_access_logs.arn, "${aws_cloudwatch_log_group.apigw_access_logs.arn}:*"]
   }
 }
 resource "aws_iam_role_policy" "cloudwatch" {

--- a/terraform/apigw.tf
+++ b/terraform/apigw.tf
@@ -93,12 +93,6 @@ resource "aws_cloudwatch_log_group" "apigw_access_logs" {
   name = "/aws/apigateway/${local.name}-access-logs"
 }
 
-
-// Create API Gateway Account for logging
-resource "aws_api_gateway_account" "apgw_account" {
-  cloudwatch_role_arn = aws_iam_role.cloudwatch.arn
-}
-
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -44,11 +44,6 @@ resource "aws_iam_role_policy" "lambda_signing_policy" {
     Statement = [
       {
         Effect   = "Allow"
-        Action   = ["kms:Sign", "kms:GetPublicKey"]
-        Resource = aws_kms_key.ssh_user_ca_key.arn
-      },
-      {
-        Effect   = "Allow"
         Action   = "dynamodb:PutItem"
         Resource = aws_dynamodb_table.audit_table.arn
       },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,9 +41,3 @@ variable "lambda_runtime" {
   type        = string
   default     = "provided.al2023"
 }
-
-variable "lambda_zip_sha256" {
-  description = "SHA256 hash of the Lambda deployment package"
-  type        = string
-  default     = ""
-}


### PR DESCRIPTION
## Summary
- Narrow CloudWatch IAM policy to specific log group ARN (was `*`)
- Remove `aws_api_gateway_account` resource (only applies to REST API Gateway, not HTTP API)
- Remove unused `lambda_zip_sha256` variable
- Consolidate duplicate KMS IAM statements